### PR TITLE
Reinitialize connection on server restart

### DIFF
--- a/discord/ext/ipc/client.py
+++ b/discord/ext/ipc/client.py
@@ -147,9 +147,9 @@ class Client:
             log.error(
                 "WebSocket connection unexpectedly closed. IPC Server is unreachable."
             )
-            return {
-                "error": "IPC Server Unreachable, restart client process.",
-                "code": 500,
-            }
+            await self.session.close()
+            await self.init_sock()
+
+            return await self.request(endpoint, **kwargs)
 
         return recv.json()


### PR DESCRIPTION
### Description

This PR attempts to solve an issue wherein the client needs to be manually restarted if the IPC server is restarted. It isn't always possible to have a manual intervention so this is a workaround.  

The basic idea is to close the current session and attempt to reinitialize the socket if the connection is lost. If the connection is established, retry the request. If not, the error will be raised from `init_sock()` (Say the server isn't actually restarted but it goes offline)

### Checklist

- [x] This PR has been tested.
