### PR TITLE
Use futures to allow concurrent send and receive

### DIFF
--- a/discord/ext/ipc/client.py
+++ b/discord/ext/ipc/client.py
@@ -131,7 +131,7 @@ class Client:
         }
 
         self._queue.put_nowait(payload)
-        self._requests[nonce] = future = asyncio.create_future()
+        self._requests[nonce] = future = self.loop.create_future()
         return await asyncio.wait_for(future, timeout)
 
     async def _send_requests(self):

--- a/discord/ext/ipc/client.py
+++ b/discord/ext/ipc/client.py
@@ -14,7 +14,7 @@
 import asyncio
 import logging
 import typing
-import uuid
+import os
 import weakref
 
 import aiohttp

--- a/discord/ext/ipc/client.py
+++ b/discord/ext/ipc/client.py
@@ -14,6 +14,8 @@
 import asyncio
 import logging
 import typing
+import uuid
+import weakref
 
 import aiohttp
 from discord.ext.ipc.errors import *
@@ -56,6 +58,11 @@ class Client:
         self.multicast = None
 
         self.multicast_port = multicast_port
+
+        self._requests = weakref.WeakValueDictionary()
+        self._queue = asyncio.Queue()
+        self._worker = None
+        self._sender = None
 
     @property
     def url(self):
@@ -103,57 +110,98 @@ class Client:
         )
         log.info("Client connected to %s", self.url)
 
+        if self._worker is None:
+            self._worker = self.loop.create_task(self._receive_requests())
+        if self._sender is None:
+            self._sender = self.loop.create_task(self._send_requests())
+
         return self.websocket
 
-    async def request(self, endpoint: str, **kwargs):
+    async def request(self, endpoint: str, timeout: float = None, **kwargs):
         """Make a request to the IPC server process.
 
         Parameters
         ----------
         endpoint: str
             The endpoint to request on the server
+        timeout: float
+            The number of seconds to wait for a response from the server
+            before timing out and raising :exc:`asyncio.TimeoutError`.
+            By default this is ``None`` and waits forever.
         **kwargs
             The data to send to the endpoint
+
+        Raises
+        -------
+        asyncio.TimeoutError
+            If a timeout is provided and it was reached.
         """
         log.info("Requesting IPC Server for %r with %r", endpoint, kwargs)
         if not self.session:
             await self.init_sock()
 
+        # generate a unique identifier for this request
+        # there is probably a better way to do this
+        nonce = uuid.uuid1()
+
         payload = {
             "endpoint": endpoint,
             "data": kwargs,
             "headers": {"Authorization": self.secret_key},
+            "nonce": nonce,
         }
 
-        await self.websocket.send_json(payload)
+        self._queue.put_nowait(payload)
+        self._requests[nonce] = future = asyncio.create_future()
+        return await asyncio.wait_for(future, timeout)
 
-        log.debug("Client > %r", payload)
+    async def _send_requests(self):
+        while True:
+            payload = await self._queue.get()
+            await self.websocket.send_json(payload)
+            log.debug("Client > %r", payload)
 
-        recv = await self.websocket.receive()
+    async def _receive_requests(self):
+        while True:
+            recv = await self.websocket.receive()
+            log.debug("Client < %r", recv)
 
-        log.debug("Client < %r", recv)
+            if recv.type == aiohttp.WSMsgType.PING:
+                log.info("Received request to PING")
+                await self.websocket.ping()
 
-        if recv.type == aiohttp.WSMsgType.PING:
-            log.info("Received request to PING")
-            await self.websocket.ping()
+            elif recv.type == aiohttp.WSMsgType.PONG:
+                log.info("Received PONG")
 
-            return await self.request(endpoint, **kwargs)
+            elif recv.type == aiohttp.WSMsgType.CLOSED:
+                log.error(
+                    "WebSocket connection unexpectedly closed. IPC Server is unreachable. Attempting reconnection in 5 seconds."
+                )
 
-        if recv.type == aiohttp.WSMsgType.PONG:
-            log.info("Received PONG")
-            return await self.request(endpoint, **kwargs)
+                await self.session.close()
 
-        if recv.type == aiohttp.WSMsgType.CLOSED:
-            log.error(
-                "WebSocket connection unexpectedly closed. IPC Server is unreachable. Attempting reconnection in 5 seconds."
-            )
+                await asyncio.sleep(5)
 
-            await self.session.close()
+                await self.init_sock()
+            else:
+                response = recv.json()
+                nonce = response["nonce"]
+                
+                try:
+                    future = self._requests[nonce]
+                except KeyError:
+                    log.error("Received unknown request: %r", response)
+                else:
+                    ret = response.get("response", response)
+                    future.set_result(ret)
 
-            await asyncio.sleep(5)
+    async def close(self):
+        """Close the connection to the websocket."""
+        await self.session.close()
 
-            await self.init_sock()
-
-            return await self.request(endpoint, **kwargs)
-
-        return recv.json()
+        if self._worker is not None:
+            self._worker.cancel()
+            self._worker = None
+        if self._sender is not None:
+            self._sender.cancel()
+            self._sender = None

--- a/discord/ext/ipc/client.py
+++ b/discord/ext/ipc/client.py
@@ -186,7 +186,7 @@ class Client:
             else:
                 response = recv.json()
                 nonce = response["nonce"]
-                
+
                 try:
                     future = self._requests[nonce]
                 except KeyError:

--- a/discord/ext/ipc/client.py
+++ b/discord/ext/ipc/client.py
@@ -140,9 +140,7 @@ class Client:
         if not self.session:
             await self.init_sock()
 
-        # generate a unique identifier for this request
-        # there is probably a better way to do this
-        nonce = uuid.uuid1()
+        nonce = os.urandom(16).hex()
 
         payload = {
             "endpoint": endpoint,

--- a/discord/ext/ipc/server.py
+++ b/discord/ext/ipc/server.py
@@ -166,11 +166,20 @@ class Server:
                 log.info(
                     "Received unauthorized request (Invalid or no token provided)."
                 )
-                response = {"nonce": nonce, "response": {"error": "Invalid or no token provided.", "code": 403}}
+                response = {
+                    "nonce": nonce,
+                    "response": {"error": "Invalid or no token provided.", "code": 403},
+                }
             else:
                 if not endpoint or endpoint not in self.endpoints:
                     log.info("Received invalid request (Invalid or no endpoint given).")
-                    response = {"nonce": nonce, "response": {"error": "Invalid or no endpoint given.", "code": 400}}
+                    response = {
+                        "nonce": nonce,
+                        "response": {
+                            "error": "Invalid or no endpoint given.",
+                            "code": 400,
+                        },
+                    }
                 else:
                     server_response = IpcServerResponse(request)
                     attempted_cls = self.bot.cogs.get(
@@ -218,7 +227,10 @@ class Server:
                     )
                     log.error(error_response)
 
-                    response = {"nonce": nonce, "response": {"error": error_response, "code": 500}}
+                    response = {
+                        "nonce": nonce,
+                        "response": {"error": error_response, "code": 500},
+                    }
 
                     await websocket.send_json(response)
                     log.debug("IPC Server > %r", response)

--- a/discord/ext/ipc/server.py
+++ b/discord/ext/ipc/server.py
@@ -160,6 +160,8 @@ class Server:
 
             headers = request.get("headers")
 
+            nonce = request.get("nonce")
+
             if not headers or headers.get("Authorization") != self.secret_key:
                 log.info(
                     "Received unauthorized request (Invalid or no token provided)."
@@ -199,7 +201,7 @@ class Server:
                         }
 
             try:
-                await websocket.send_json(response)
+                await websocket.send_json({"nonce": nonce, "response": response})
                 log.debug("IPC Server > %r", response)
             except TypeError as error:
                 if str(error).startswith("Object of type") and str(error).endswith(


### PR DESCRIPTION
<!-- Please read the contributing guidelines before opening this pull request. -->


### Description
<!-- What does this PR do? -->

Rewrite the logic of the client (and server) to allow for concurrent sends and receives.
Resolves the issue found by several library users when calling `Client.request(...)` very quickly:
```
  File "/projectpath/venv/lib/python3.9/site-packages/discord/ext/ipc/client.py", line 104, in request
    recv = await self.websocket.receive()
  File "/projectpath/venv/lib/python3.9/site-packages/aiohttp/client_ws.py", line 216, in receive
    raise RuntimeError("Concurrent call to receive() is not allowed")
RuntimeError: Concurrent call to receive() is not allowed
```


### Checklist
<!-- All of the boxes should be checked before you open the pull request. -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

<!-- Please remember to test your PR before you open it. -->
- [ ] This PR has been tested.
