### PR TITLE
have IPCError inherit DiscordException

### DIFF
--- a/discord/ext/ipc/errors.py
+++ b/discord/ext/ipc/errors.py
@@ -1,4 +1,7 @@
-class IPCError(Exception):
+from discord import DiscordException
+
+
+class IPCError(DiscordException):
     """Base IPC exception class"""
 
     pass


### PR DESCRIPTION
### Description

This PR changes the base for `IPCError` to `DiscordException`, following extension guarantees.

### Checklist

- [ ] This PR has been tested.
