### PR TITLE
Fix multicast-bypass not working

### DIFF
--- a/discord/ext/ipc/client.py
+++ b/discord/ext/ipc/client.py
@@ -40,9 +40,7 @@ class Client:
 
     @property
     def url(self):
-        return "ws://{0.host}:{1}".format(
-            self, self.port if self.port else self.multicast_port
-        )
+        return "ws://{0.host}:{1}".format(self, self.port if self.port else self.multicast_port)
 
     async def init_sock(self):
         """Attempts to connect to the server

--- a/discord/ext/ipc/client.py
+++ b/discord/ext/ipc/client.py
@@ -41,7 +41,7 @@ class Client:
     @property
     def url(self):
         return "ws://{0.host}:{1}".format(
-            self, self.port if self.multicast else self.multicast_port
+            self, self.port if self.port else self.multicast_port
         )
 
     async def init_sock(self):


### PR DESCRIPTION
### Description
Currently there exists an issue where no matter your client configuration, the client will always attempt to do multicasting, even if a port is explicitly provided, and `do_multicast` is set to False server-side. This PR tries to fix that, and although this fixed the issue in my project, it could still be flawed in some other way I could not foresee.


### Checklist

- [x] This PR has been tested.
