### PR TITLE
Fix cog reloading not reloading IPC routes

### DIFF
--- a/discord/ext/ipc/server.py
+++ b/discord/ext/ipc/server.py
@@ -156,13 +156,17 @@ class Server:
                     response = {"error": "Invalid or no endpoint given.", "code": 400}
                 else:
                     server_response = IpcServerResponse(request)
-                    attempted_cls = self.bot.cogs.get(
-                        self.endpoints[endpoint].__qualname__.split(".")[0]
-                    )
+                    try:
+                        attempted_cls = self.bot.cogs.get(
+                            self.endpoints[endpoint].__qualname__.split(".")[0]
+                        )
 
-                    if attempted_cls:
-                        arguments = (attempted_cls, server_response)
-                    else:
+                        if attempted_cls:
+                            arguments = (attempted_cls, server_response)
+                        else:
+                            arguments = (server_response,)
+                    except AttributeError:
+                        # Support base Client
                         arguments = (server_response,)
 
                     try:


### PR DESCRIPTION
### Description
Previously when reloading a cog with attached IPC routes, the server would not update the endpoints. This resolves that.

Resolved it by removing the un-needed `endpoints` attribute and relying on `ROUTES` for two reasons:
 - Firstly, `**` unpacking favours one side, so this could lead to issues with updating
 - Secondly, `update_endpoints` was only called on initial creation. Further requests would always be from [here](https://github.com/Ext-Creators/discord-ext-ipc/blob/main/discord/ext/ipc/server.py#L141) which wouldn't mean endpoints got updated.
     - Note, adding `update_endpoints` within this didn't appear to resolve the issue during my albiet short testing 


### Checklist
- [x] This PR has been tested.
